### PR TITLE
Make SPA entrypoint more intuitive

### DIFF
--- a/src/spa.ts
+++ b/src/spa.ts
@@ -41,12 +41,12 @@ async function navigate(url: URL, isBack: boolean = false, opts: Options) {
     window.scrollTo({ top: 0 });
   }
   const html = p.parseFromString(contents, "text/html");
+  normalizeRelativeURLs(html, url);
+  beforeDiff(html);
   const title = html.querySelector("title");
   if (title) {
     document.title = title.text;
   }
-  normalizeRelativeURLs(html, url);
-  beforeDiff(html);
   await micromorph(document, html);
   afterDiff();
 }

--- a/src/spa.ts
+++ b/src/spa.ts
@@ -30,17 +30,21 @@ let p: DOMParser;
 async function navigate(url: URL, isBack: boolean = false, opts: Options) {
   const { beforeDiff = noop, afterDiff = noop } = opts;
   p = p || new DOMParser();
-  if (!isBack) {
-    history.pushState({}, "", url);
-    window.scrollTo({ top: 0 });
-  }
   const contents = await fetch(`${url}`)
     .then((res) => res.text())
     .catch(() => {
       window.location.assign(url);
     });
   if (!contents) return;
+  if (!isBack) {
+    history.pushState({}, "", url);
+    window.scrollTo({ top: 0 });
+  }
   const html = p.parseFromString(contents, "text/html");
+  const title = html.querySelector("title");
+  if (title) {
+    document.title = title.text;
+  }
   normalizeRelativeURLs(html, url);
   beforeDiff(html);
   await micromorph(document, html);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,10 +6,10 @@ export function normalizeRelativeURLs(
   el: Element | Document,
   base: string | URL
 ) {
-  el.querySelectorAll(':is([href^="./"], [href^="../"])').forEach((item) =>
+  el.querySelectorAll('[href^="./"], [href^="../"]').forEach((item) =>
     update(item, 'href', base)
   );
-  el.querySelectorAll(':is([src^="./"], [src^="../"])').forEach((item) =>
+  el.querySelectorAll('[src^="./"], [src^="../"]').forEach((item) =>
     update(item, 'src', base)
   );
 }


### PR DESCRIPTION
Very awesome library! I especially like that you included a non-trivial SPA integration to be used out of the box.

This PR tries to improve the SPA entrypoint a bit:

- Update the URL and scroll to top after fetching the document. This matches the default behavior of popular router libraries and avoid the awkward scenario that the page scrolls despite it fetched nothing.
- Update document title. I don't know why this is not handled in the DOM update though.
- Took the chance to remove unnecessary `:is()` for better compatibility 