### PR TITLE
Adding options to filter anchor elements and disable scrollToTop

### DIFF
--- a/spa.d.ts
+++ b/spa.d.ts
@@ -1,5 +1,7 @@
 interface Options {
   beforeDiff?: (newDocument: Document) => void|Promise<void>;
-  afterDiff?: () => void|Promise<void>
+  afterDiff?: () => void|Promise<void>;
+  include?: string | ((element: HTMLAnchorElement) => boolean);
+  scrollToTop?: boolean;
 }
 export default function listen(opts?: Options): void;


### PR DESCRIPTION
[x] adds new `includes` option used to filter which anchor elements are client-side routed.  Can be a string DOM selector or filter function
[x] adds new `scrollToTop` option to disable scrolling on navigation (still enabled by default)