### PR TITLE
Fix demo script: --filter <pkg> should come before <command>

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "pnpm run build:index && pnpm run build:spa",
     "build:index": "esbuild src/index.ts --bundle --format=esm --target=es2020 --outfile=dist/index.js --minify",
     "build:spa": "esbuild src/spa.ts --bundle --format=esm --target=es2020 --outfile=dist/spa.js --minify",
-    "demo": "pnpm run build --filter demo && pnpm run preview --filter demo"
+    "demo": "pnpm --filter demo run build && pnpm --filter demo run preview"
   },
   "devDependencies": {
     "@changesets/cli": "^2.22.0",


### PR DESCRIPTION
Just noticed that `demo` script was broken due to the incorrect ordering of `--filter <pkg>` part. (https://pnpm.io/filtering).