### PR TITLE
Update package.json to explicitly export types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,18 @@
   "main": "./index.mjs",
   "types": "./types.d.ts",
   "exports": {
-    ".": "./index.mjs",
-    "./spa": "./dist/spa.js",
-    "./nav": "./dist/nav.js"
+    ".": {
+      "import": "./index.mjs",
+      "types": "./index.d.ts"
+    },
+    "./spa": {
+      "import": "./dist/spa.js",
+      "types": "./spa.d.ts"
+    },
+    "./nav": {
+      "import": "./dist/nav.js",
+      "types": "./nav.d.ts"
+    }
   },
   "files": [
     "index.mjs",


### PR DESCRIPTION
I got type errors when importing `micromorph/nav`, telling me that it recognized `nav.d.ts` in the project root, but because it wasn't explicitly exported in the `package.json` it couldn't use it. This small change fixes it.